### PR TITLE
Feat: Added support to override the dependency-check parser

### DIFF
--- a/bin/mongodb-js-precommit.js
+++ b/bin/mongodb-js-precommit.js
@@ -8,7 +8,8 @@ var figures = require('figures');
 
 var usage = fs.readFileSync(path.resolve(__dirname, '../usage.txt')).toString();
 var args = require('minimist')(process.argv.slice(2), {
-  boolean: ['debug', 'json']
+  boolean: ['debug', 'json'],
+  string: ['detective']
 });
 
 if (args.debug) {

--- a/index.js
+++ b/index.js
@@ -74,7 +74,8 @@ function check(options, mode, done) {
   var opts = {
     path: path.join(options.dir, 'package.json'),
     entries: pkg['dependency-check'].entries,
-    ignore: pkg['dependency-check'].ignore
+    ignore: pkg['dependency-check'].ignore,
+    detective: options.detective || 'precinct'
   };
   opts.ignore = opts.ignore || [];
   opts.entries = opts.entries || [];
@@ -251,6 +252,7 @@ module.exports = function(opts, done) {
     files: [],
     dry: false,
     json: false,
+    detective: 'precinct',
     formatted: [],
     unchanged: [],
     result: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -211,6 +211,12 @@
         "concat-map": "0.0.1"
       }
     },
+    "browser-stdout": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
+      "integrity": "sha1-81HTKWnTL6XXpVZxVCY9korjvR8=",
+      "dev": true
+    },
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
@@ -1300,9 +1306,9 @@
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "growl": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.9.2.tgz",
-      "integrity": "sha1-Dqd0NxXbjY3ixe3hd14bRayFwC8=",
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
+      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
       "dev": true
     },
     "has": {
@@ -1321,6 +1327,18 @@
       "requires": {
         "ansi-regex": "2.1.1"
       }
+    },
+    "has-flag": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "dev": true
+    },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
+      "dev": true
     },
     "hosted-git-info": {
       "version": "2.5.0",
@@ -1505,30 +1523,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
-    },
-    "jade": {
-      "version": "0.26.3",
-      "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
-      "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
-      "dev": true,
-      "requires": {
-        "commander": "0.6.1",
-        "mkdirp": "0.3.0"
-      },
-      "dependencies": {
-        "commander": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
-          "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
-          "dev": true
-        },
-        "mkdirp": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
-          "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
-          "dev": true
-        }
-      }
     },
     "js-tokens": {
       "version": "3.0.1",
@@ -1818,12 +1812,6 @@
         "js-tokens": "3.0.1"
       }
     },
-    "lru-cache": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.7.3.tgz",
-      "integrity": "sha1-bUUk6LlV+V1PW1iFHOId1y+06VI=",
-      "dev": true
-    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -1853,69 +1841,57 @@
       }
     },
     "mocha": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
-      "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-4.0.1.tgz",
+      "integrity": "sha512-evDmhkoA+cBNiQQQdSKZa2b9+W2mpLoj50367lhy+Klnx9OV8XlCIhigUnn1gaTFLQCa0kdNhEGDr0hCXOQFDw==",
       "dev": true,
       "requires": {
-        "commander": "2.3.0",
-        "debug": "2.2.0",
-        "diff": "1.4.0",
-        "escape-string-regexp": "1.0.2",
-        "glob": "3.2.11",
-        "growl": "1.9.2",
-        "jade": "0.26.3",
+        "browser-stdout": "1.3.0",
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "diff": "3.3.1",
+        "escape-string-regexp": "1.0.5",
+        "glob": "7.1.2",
+        "growl": "1.10.3",
+        "he": "1.1.1",
         "mkdirp": "0.5.1",
-        "supports-color": "1.2.0",
-        "to-iso-string": "0.0.2"
+        "supports-color": "4.4.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true,
-          "requires": {
-            "ms": "0.7.1"
-          }
+        "commander": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+          "dev": true
         },
-        "escape-string-regexp": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz",
-          "integrity": "sha1-Tbwv5nTnGUnK8/smlc5/LcHZqNE=",
+        "diff": {
+          "version": "3.3.1",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
+          "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
           "dev": true
         },
         "glob": {
-          "version": "3.2.11",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "dev": true,
           "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
             "inherits": "2.0.3",
-            "minimatch": "0.3.0"
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
           }
-        },
-        "minimatch": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-          "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-          "dev": true,
-          "requires": {
-            "lru-cache": "2.7.3",
-            "sigmund": "1.0.1"
-          }
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
         },
         "supports-color": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz",
-          "integrity": "sha1-/x7R5hFp0Gs88tWI4YixjYhH4X4=",
-          "dev": true
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
+          "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
         }
       }
     },
@@ -2530,12 +2506,6 @@
         }
       }
     },
-    "sigmund": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
-      "dev": true
-    },
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
@@ -2700,12 +2670,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-      "dev": true
-    },
-    "to-iso-string": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/to-iso-string/-/to-iso-string-0.0.2.tgz",
-      "integrity": "sha1-TcGeZk38y+Jb2NtQiwDG2hWCVdE=",
       "dev": true
     },
     "tryit": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,6 +2,7 @@
   "name": "mongodb-js-precommit",
   "version": "0.3.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "acorn": {
       "version": "4.0.13",
@@ -12,6 +13,9 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+      "requires": {
+        "acorn": "3.3.0"
+      },
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
@@ -29,7 +33,11 @@
     "ajv": {
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY="
+      "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+      "requires": {
+        "co": "4.6.0",
+        "json-stable-stringify": "1.0.1"
+      }
     },
     "ajv-keywords": {
       "version": "1.5.1",
@@ -61,12 +69,18 @@
     "argparse": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
-      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY="
+      "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "requires": {
+        "sprintf-js": "1.0.3"
+      }
     },
     "array-union": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk="
+      "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+      "requires": {
+        "array-uniq": "1.0.3"
+      }
     },
     "array-uniq": {
       "version": "1.0.3",
@@ -77,12 +91,21 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.0.4.tgz",
       "integrity": "sha1-VWpcU2LAhkgyPdrrnenRS8GGTJA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "es-abstract": "1.9.0"
+      }
     },
     "arrify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
       "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0="
+    },
+    "ast-module-types": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/ast-module-types/-/ast-module-types-2.3.2.tgz",
+      "integrity": "sha1-S7HeLXKWeIJEKeIqYo0D6H30rRE="
     },
     "async": {
       "version": "1.5.2",
@@ -92,51 +115,87 @@
     "babel-code-frame": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
-      "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ="
+      "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+      "requires": {
+        "chalk": "1.1.3",
+        "esutils": "2.0.2",
+        "js-tokens": "3.0.1"
+      }
     },
     "babel-eslint": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-6.1.2.tgz",
-      "integrity": "sha1-UpNBn+NnLWZZjTJ9qWlFZ7pqXy8=",
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-7.2.3.tgz",
+      "integrity": "sha1-sv4tgBJkcPXBlELcdXJTqJdxCCc=",
       "dev": true,
-      "dependencies": {
-        "lodash.assign": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
-          "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc=",
-          "dev": true
-        }
+      "requires": {
+        "babel-code-frame": "6.22.0",
+        "babel-traverse": "6.25.0",
+        "babel-types": "6.25.0",
+        "babylon": "6.17.3"
       }
     },
     "babel-messages": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0"
+      }
     },
     "babel-runtime": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
       "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
-      "dev": true
+      "requires": {
+        "core-js": "2.4.1",
+        "regenerator-runtime": "0.10.5"
+      }
     },
     "babel-traverse": {
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.25.0.tgz",
       "integrity": "sha1-IldJfi/NGbie3BPEyROB+VEklvE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-code-frame": "6.22.0",
+        "babel-messages": "6.23.0",
+        "babel-runtime": "6.23.0",
+        "babel-types": "6.25.0",
+        "babylon": "6.17.3",
+        "debug": "2.6.9",
+        "globals": "9.18.0",
+        "invariant": "2.2.2",
+        "lodash": "4.17.4"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
     },
     "babel-types": {
       "version": "6.25.0",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.25.0.tgz",
       "integrity": "sha1-cK+ySNVmDl0Y+BHZHIMDtUE0oY4=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "babel-runtime": "6.23.0",
+        "esutils": "2.0.2",
+        "lodash": "4.17.4",
+        "to-fast-properties": "1.0.3"
+      }
     },
     "babylon": {
       "version": "6.17.3",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.17.3.tgz",
-      "integrity": "sha512-mq0x3HCAGGmQyZXviOVe5TRsw37Ijy3D43jCqt/9WVf+onx2dUgW3PosnqCbScAFhRO9DGs8nxoMzU0iiosMqQ==",
-      "dev": true
+      "integrity": "sha512-mq0x3HCAGGmQyZXviOVe5TRsw37Ijy3D43jCqt/9WVf+onx2dUgW3PosnqCbScAFhRO9DGs8nxoMzU0iiosMqQ=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -146,7 +205,11 @@
     "brace-expansion": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
-      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI="
+      "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "requires": {
+        "balanced-match": "1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "builtin-modules": {
       "version": "1.1.1",
@@ -161,7 +224,10 @@
     "caller-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
-      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8="
+      "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+      "requires": {
+        "callsites": "0.2.0"
+      }
     },
     "callsites": {
       "version": "0.2.0",
@@ -171,7 +237,14 @@
     "chalk": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "escape-string-regexp": "1.0.5",
+        "has-ansi": "2.0.0",
+        "strip-ansi": "3.0.1",
+        "supports-color": "2.0.0"
+      }
     },
     "circular-json": {
       "version": "0.3.1",
@@ -181,7 +254,10 @@
     "cli-cursor": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
-      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc="
+      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "requires": {
+        "restore-cursor": "1.0.1"
+      }
     },
     "cli-width": {
       "version": "2.1.0",
@@ -212,13 +288,17 @@
     "concat-stream": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
-      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc="
+      "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "requires": {
+        "inherits": "2.0.3",
+        "readable-stream": "2.2.11",
+        "typedarray": "0.0.6"
+      }
     },
     "core-js": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.1.tgz",
-      "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4=",
-      "dev": true
+      "integrity": "sha1-TekR5mew6ukSTjQlS1OupvxhjT4="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -230,24 +310,39 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
+      "requires": {
+        "lru-cache": "4.1.1",
+        "shebang-command": "1.2.0",
+        "which": "1.2.14"
+      },
       "dependencies": {
         "lru-cache": {
           "version": "4.1.1",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
           "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "pseudomap": "1.0.2",
+            "yallist": "2.1.2"
+          }
         }
       }
     },
     "d": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8="
+      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+      "requires": {
+        "es5-ext": "0.10.23"
+      }
     },
     "debug": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+      "requires": {
+        "ms": "2.0.0"
+      }
     },
     "deep-extend": {
       "version": "0.4.2",
@@ -264,7 +359,11 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "foreach": "2.0.5",
+        "object-keys": "1.0.11"
+      }
     },
     "defined": {
       "version": "1.0.0",
@@ -274,24 +373,189 @@
     "del": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
-      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag="
+      "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+      "requires": {
+        "globby": "5.0.0",
+        "is-path-cwd": "1.0.0",
+        "is-path-in-cwd": "1.0.0",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1",
+        "rimraf": "2.6.1"
+      }
     },
     "dependency-check": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/dependency-check/-/dependency-check-2.9.0.tgz",
-      "integrity": "sha1-5HjeTdMpSQVZ+GALA6JdDHZvyAk=",
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/dependency-check/-/dependency-check-2.9.1.tgz",
+      "integrity": "sha1-Iovbp2jjv4GaKmjDbz9qdzxCbr8=",
+      "requires": {
+        "async": "2.6.0",
+        "builtins": "1.0.3",
+        "debug": "2.6.9",
+        "detective": "4.5.0",
+        "is-relative": "0.2.1",
+        "minimist": "1.2.0",
+        "read-package-json": "2.0.12",
+        "resolve": "1.3.3"
+      },
       "dependencies": {
         "async": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.4.1.tgz",
-          "integrity": "sha1-YqVrJ5yYoR0JhwlqAcw+6463u9c="
+          "version": "2.6.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
+          "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+          "requires": {
+            "lodash": "4.17.4"
+          }
+        },
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
         }
       }
     },
     "detective": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/detective/-/detective-4.5.0.tgz",
-      "integrity": "sha1-blqMaybmx6JUsca210kNmOyR7dE="
+      "integrity": "sha1-blqMaybmx6JUsca210kNmOyR7dE=",
+      "requires": {
+        "acorn": "4.0.13",
+        "defined": "1.0.0"
+      }
+    },
+    "detective-amd": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/detective-amd/-/detective-amd-2.4.0.tgz",
+      "integrity": "sha1-XrDfTvXBipQDOwfa8TbbzV/HXNU=",
+      "requires": {
+        "ast-module-types": "2.3.2",
+        "escodegen": "1.9.0",
+        "get-amd-module-type": "2.0.5",
+        "node-source-walk": "3.3.0"
+      },
+      "dependencies": {
+        "escodegen": {
+          "version": "1.9.0",
+          "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
+          "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
+          "requires": {
+            "esprima": "3.1.3",
+            "estraverse": "4.2.0",
+            "esutils": "2.0.2",
+            "optionator": "0.8.2",
+            "source-map": "0.5.7"
+          }
+        },
+        "esprima": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "optional": true
+        }
+      }
+    },
+    "detective-cjs": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/detective-cjs/-/detective-cjs-2.0.0.tgz",
+      "integrity": "sha1-3OTJMCzcpS5ri/04d8qT9ixczAM=",
+      "requires": {
+        "ast-module-types": "2.3.2",
+        "node-source-walk": "3.3.0"
+      }
+    },
+    "detective-es6": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/detective-es6/-/detective-es6-1.2.0.tgz",
+      "integrity": "sha1-a5s71Uf9jyH4lQL2JuRe0qMnb9w=",
+      "requires": {
+        "node-source-walk": "3.3.0"
+      }
+    },
+    "detective-less": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/detective-less/-/detective-less-1.0.0.tgz",
+      "integrity": "sha1-Qmx4yatuMnW/ZsyRq6wAU7tFLX0=",
+      "requires": {
+        "debug": "2.2.0",
+        "gonzales-pe": "3.4.7",
+        "node-source-walk": "3.3.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "requires": {
+            "ms": "0.7.1"
+          }
+        },
+        "ms": {
+          "version": "0.7.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg="
+        }
+      }
+    },
+    "detective-sass": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/detective-sass/-/detective-sass-2.0.1.tgz",
+      "integrity": "sha1-BWYKoblc/Yf1dGQ7+s4+iiaBEqE=",
+      "requires": {
+        "debug": "3.1.0",
+        "gonzales-pe": "3.4.7",
+        "node-source-walk": "3.3.0"
+      }
+    },
+    "detective-scss": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/detective-scss/-/detective-scss-1.0.1.tgz",
+      "integrity": "sha1-dDJGoN01jZ2R/0ElQX9qd/vPJw8=",
+      "requires": {
+        "debug": "3.1.0",
+        "gonzales-pe": "3.4.7",
+        "node-source-walk": "3.3.0"
+      }
+    },
+    "detective-stylus": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/detective-stylus/-/detective-stylus-1.0.0.tgz",
+      "integrity": "sha1-UK7n24uruZA4HwEMY/q7pbWOVM0="
+    },
+    "detective-typescript": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/detective-typescript/-/detective-typescript-1.0.1.tgz",
+      "integrity": "sha512-4DZpsap+dVzQblcL/ffVXtaXtA7byrP14XQnvyAvwo8+z7/C0OrwLNQhyiC6cLZlzy2T8QuPc+mDsYsa4lAxHw==",
+      "requires": {
+        "node-source-walk": "3.2.0",
+        "typescript": "2.0.10",
+        "typescript-eslint-parser": "1.0.2"
+      },
+      "dependencies": {
+        "babylon": {
+          "version": "6.8.4",
+          "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.8.4.tgz",
+          "integrity": "sha1-CXMGuNq66VFZIlzymz6lWRIFMYA=",
+          "requires": {
+            "babel-runtime": "6.23.0"
+          }
+        },
+        "node-source-walk": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-3.2.0.tgz",
+          "integrity": "sha1-PGBcxTq97ktFq2XpR9+x23yQ8OM=",
+          "requires": {
+            "babylon": "6.8.4"
+          }
+        }
+      }
     },
     "diff": {
       "version": "1.4.0",
@@ -303,7 +567,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/disparity/-/disparity-2.0.0.tgz",
       "integrity": "sha1-V92stHMkrl9Y0swNqIbbTOnutxg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "ansi-styles": "2.2.1",
+        "diff": "1.4.0"
+      }
     },
     "docopt": {
       "version": "0.4.1",
@@ -314,49 +582,99 @@
     "doctrine": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
-      "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM="
+      "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+      "requires": {
+        "esutils": "2.0.2",
+        "isarray": "1.0.0"
+      }
     },
     "es-abstract": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.7.0.tgz",
-      "integrity": "sha1-363ndOAb/Nl/lhgCmMRJyGI/uUw=",
-      "dev": true
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.9.0.tgz",
+      "integrity": "sha512-kk3IJoKo7A3pWJc0OV8yZ/VEX2oSUytfekrJiqoxBlKJMFAJVJVpGdHClCCTdv+Fn2zHfpDHHIelMFhZVfef3Q==",
+      "dev": true,
+      "requires": {
+        "es-to-primitive": "1.1.1",
+        "function-bind": "1.1.1",
+        "has": "1.0.1",
+        "is-callable": "1.1.3",
+        "is-regex": "1.0.4"
+      }
     },
     "es-to-primitive": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "is-callable": "1.1.3",
+        "is-date-object": "1.0.1",
+        "is-symbol": "1.0.1"
+      }
     },
     "es5-ext": {
       "version": "0.10.23",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz",
-      "integrity": "sha1-dXi1G+l0IHpUh4IbVlOMIk5Oezg="
+      "integrity": "sha1-dXi1G+l0IHpUh4IbVlOMIk5Oezg=",
+      "requires": {
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1"
+      }
     },
     "es6-iterator": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
-      "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI="
+      "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23",
+        "es6-symbol": "3.1.1"
+      }
     },
     "es6-map": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
-      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA="
+      "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23",
+        "es6-iterator": "2.0.1",
+        "es6-set": "0.1.5",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      }
     },
     "es6-set": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
-      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE="
+      "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23",
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1",
+        "event-emitter": "0.3.5"
+      }
     },
     "es6-symbol": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
-      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc="
+      "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23"
+      }
     },
     "es6-weak-map": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
-      "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8="
+      "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23",
+        "es6-iterator": "2.0.1",
+        "es6-symbol": "3.1.1"
+      }
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -368,6 +686,13 @@
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.7.1.tgz",
       "integrity": "sha1-MOz89mypjcZ80v0WKr626vqM5vw=",
       "dev": true,
+      "requires": {
+        "esprima": "1.2.5",
+        "estraverse": "1.9.3",
+        "esutils": "2.0.2",
+        "optionator": "0.5.0",
+        "source-map": "0.2.0"
+      },
       "dependencies": {
         "esprima": {
           "version": "1.2.5",
@@ -391,13 +716,25 @@
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz",
           "integrity": "sha1-uo0znQykphDjo/FFucr0iAcVUFQ=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "prelude-ls": "1.1.2",
+            "type-check": "0.3.2"
+          }
         },
         "optionator": {
           "version": "0.5.0",
           "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz",
           "integrity": "sha1-t1qJlaLUF98ltuTjhi9QqohlE2g=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "deep-is": "0.1.3",
+            "fast-levenshtein": "1.0.7",
+            "levn": "0.2.5",
+            "prelude-ls": "1.1.2",
+            "type-check": "0.3.2",
+            "wordwrap": "0.0.3"
+          }
         },
         "wordwrap": {
           "version": "0.0.3",
@@ -410,13 +747,41 @@
     "escope": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
-      "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM="
+      "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+      "requires": {
+        "es6-map": "0.1.5",
+        "es6-weak-map": "2.0.2",
+        "esrecurse": "4.1.0",
+        "estraverse": "4.2.0"
+      }
     },
     "esformatter": {
       "version": "0.9.6",
       "resolved": "https://registry.npmjs.org/esformatter/-/esformatter-0.9.6.tgz",
       "integrity": "sha1-Ngiux4KN7uPNP0bhGSrrRyaKlX8=",
       "dev": true,
+      "requires": {
+        "acorn-to-esprima": "2.0.8",
+        "babel-traverse": "6.25.0",
+        "debug": "0.7.4",
+        "disparity": "2.0.0",
+        "esformatter-parser": "1.0.0",
+        "glob": "5.0.15",
+        "minimist": "1.2.0",
+        "mout": "1.0.0",
+        "npm-run": "2.0.0",
+        "resolve": "1.3.3",
+        "rocambole": "0.7.0",
+        "rocambole-indent": "2.0.4",
+        "rocambole-linebreak": "1.0.2",
+        "rocambole-node": "1.0.0",
+        "rocambole-token": "1.2.1",
+        "rocambole-whitespace": "1.0.0",
+        "stdin": "0.0.1",
+        "strip-json-comments": "0.1.3",
+        "supports-color": "1.3.1",
+        "user-home": "2.0.0"
+      },
       "dependencies": {
         "debug": {
           "version": "0.7.4",
@@ -428,13 +793,23 @@
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "rocambole": {
           "version": "0.7.0",
           "resolved": "https://registry.npmjs.org/rocambole/-/rocambole-0.7.0.tgz",
           "integrity": "sha1-9seVBVF9xCtvuECEK4uVOw+WhYU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "esprima": "2.7.3"
+          }
         },
         "strip-json-comments": {
           "version": "0.1.3",
@@ -453,24 +828,39 @@
     "esformatter-braces": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/esformatter-braces/-/esformatter-braces-1.2.1.tgz",
-      "integrity": "sha1-c+BxdEat5LsmnO7OtGw3AujB6Cc="
+      "integrity": "sha1-c+BxdEat5LsmnO7OtGw3AujB6Cc=",
+      "requires": {
+        "rocambole-token": "1.2.1"
+      }
     },
     "esformatter-dot-notation": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/esformatter-dot-notation/-/esformatter-dot-notation-1.3.1.tgz",
-      "integrity": "sha1-21uqJBQyFOVA+jJ9JV7rBPWxV+A="
+      "integrity": "sha1-21uqJBQyFOVA+jJ9JV7rBPWxV+A=",
+      "requires": {
+        "rocambole": "0.6.0",
+        "rocambole-token": "1.2.1",
+        "unquoted-property-validator": "1.0.0"
+      }
     },
     "esformatter-eol-last": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/esformatter-eol-last/-/esformatter-eol-last-1.0.0.tgz",
       "integrity": "sha1-RaeP9GIrHUnkT1a0mQV2amMpDAc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "string.prototype.endswith": "0.2.0"
+      }
     },
     "esformatter-parseint": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/esformatter-parseint/-/esformatter-parseint-1.0.3.tgz",
       "integrity": "sha1-pHQIfGgtMxSa8xuv8eYWpdc7Zug=",
       "dev": true,
+      "requires": {
+        "rocambole": "0.3.6",
+        "rocambole-token": "1.2.1"
+      },
       "dependencies": {
         "esprima": {
           "version": "1.0.4",
@@ -482,7 +872,10 @@
           "version": "0.3.6",
           "resolved": "https://registry.npmjs.org/rocambole/-/rocambole-0.3.6.tgz",
           "integrity": "sha1-Teu/WUMUS8e2AG2Vvo+swLdDUqc=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "esprima": "1.0.4"
+          }
         }
       }
     },
@@ -491,19 +884,31 @@
       "resolved": "https://registry.npmjs.org/esformatter-parser/-/esformatter-parser-1.0.0.tgz",
       "integrity": "sha1-CFQHLQSHU57TnK442KVDLBfsEdM=",
       "dev": true,
+      "requires": {
+        "acorn-to-esprima": "2.0.8",
+        "babel-traverse": "6.25.0",
+        "babylon": "6.17.3",
+        "rocambole": "0.7.0"
+      },
       "dependencies": {
         "rocambole": {
           "version": "0.7.0",
           "resolved": "https://registry.npmjs.org/rocambole/-/rocambole-0.7.0.tgz",
           "integrity": "sha1-9seVBVF9xCtvuECEK4uVOw+WhYU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "esprima": "2.7.3"
+          }
         }
       }
     },
     "esformatter-quote-props": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/esformatter-quote-props/-/esformatter-quote-props-1.0.2.tgz",
-      "integrity": "sha1-dcxHv7CV2Yr0NMUM9msujFCLFZ0="
+      "integrity": "sha1-dcxHv7CV2Yr0NMUM9msujFCLFZ0=",
+      "requires": {
+        "unquoted-property-validator": "1.0.0"
+      }
     },
     "esformatter-quotes": {
       "version": "1.1.0",
@@ -513,7 +918,10 @@
     "esformatter-remove-trailing-commas": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/esformatter-remove-trailing-commas/-/esformatter-remove-trailing-commas-1.0.1.tgz",
-      "integrity": "sha1-k5diTB+qmA/E7Mfl6YE+tPK1gqc="
+      "integrity": "sha1-k5diTB+qmA/E7Mfl6YE+tPK1gqc=",
+      "requires": {
+        "rocambole-token": "1.2.1"
+      }
     },
     "esformatter-semicolons": {
       "version": "1.1.2",
@@ -530,6 +938,10 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/esformatter-var-each/-/esformatter-var-each-2.1.0.tgz",
       "integrity": "sha1-zW8pYSHBi0YLDURu1EFZgA6zlTI=",
+      "requires": {
+        "rocambole": "0.3.6",
+        "rocambole-token": "1.2.1"
+      },
       "dependencies": {
         "esprima": {
           "version": "1.0.4",
@@ -539,7 +951,10 @@
         "rocambole": {
           "version": "0.3.6",
           "resolved": "https://registry.npmjs.org/rocambole/-/rocambole-0.3.6.tgz",
-          "integrity": "sha1-Teu/WUMUS8e2AG2Vvo+swLdDUqc="
+          "integrity": "sha1-Teu/WUMUS8e2AG2Vvo+swLdDUqc=",
+          "requires": {
+            "esprima": "1.0.4"
+          }
         }
       }
     },
@@ -547,18 +962,83 @@
       "version": "3.19.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
       "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
+      "requires": {
+        "babel-code-frame": "6.22.0",
+        "chalk": "1.1.3",
+        "concat-stream": "1.6.0",
+        "debug": "2.6.9",
+        "doctrine": "2.0.0",
+        "escope": "3.6.0",
+        "espree": "3.4.3",
+        "esquery": "1.0.0",
+        "estraverse": "4.2.0",
+        "esutils": "2.0.2",
+        "file-entry-cache": "2.0.0",
+        "glob": "7.1.2",
+        "globals": "9.18.0",
+        "ignore": "3.3.3",
+        "imurmurhash": "0.1.4",
+        "inquirer": "0.12.0",
+        "is-my-json-valid": "2.16.0",
+        "is-resolvable": "1.0.0",
+        "js-yaml": "3.8.4",
+        "json-stable-stringify": "1.0.1",
+        "levn": "0.3.0",
+        "lodash": "4.17.4",
+        "mkdirp": "0.5.1",
+        "natural-compare": "1.4.0",
+        "optionator": "0.8.2",
+        "path-is-inside": "1.0.2",
+        "pluralize": "1.2.1",
+        "progress": "1.1.8",
+        "require-uncached": "1.0.3",
+        "shelljs": "0.7.8",
+        "strip-bom": "3.0.0",
+        "strip-json-comments": "2.0.1",
+        "table": "3.8.3",
+        "text-table": "0.2.0",
+        "user-home": "2.0.0"
+      },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ=="
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         }
       }
     },
     "eslint-config-mongodb-js": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-mongodb-js/-/eslint-config-mongodb-js-2.2.0.tgz",
-      "integrity": "sha1-XoFyxvv0DuGeV/QmWnLcAbtZxjM=",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-mongodb-js/-/eslint-config-mongodb-js-2.3.0.tgz",
+      "integrity": "sha512-9zxJawyp68GNX63pfqeLV47/ShSyY7Hce3l/XhrD8dihFhygs+5C7lk12ogDePK3OmOer1pREvwgR8q0YvV4Pw==",
+      "dev": true,
+      "requires": {
+        "babel-eslint": "7.2.3",
+        "eslint": "3.19.0",
+        "eslint-plugin-chai-friendly": "0.4.0",
+        "eslint-plugin-react": "6.10.3"
+      }
+    },
+    "eslint-plugin-chai-friendly": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-chai-friendly/-/eslint-plugin-chai-friendly-0.4.0.tgz",
+      "integrity": "sha512-gnkV4e1Gfb4TuhOUWD2qR8b5tMggfYrZIcFJkP20M8Hv4dXKM2EGHdhgkY9RAfxAennVgLbdEcoFiSDGgz7aUg==",
       "dev": true
     },
     "eslint-plugin-react": {
@@ -566,12 +1046,23 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-6.10.3.tgz",
       "integrity": "sha1-xUNb6wZ3ThLH2y9qut3L+QDNP3g=",
       "dev": true,
+      "requires": {
+        "array.prototype.find": "2.0.4",
+        "doctrine": "1.5.0",
+        "has": "1.0.1",
+        "jsx-ast-utils": "1.4.1",
+        "object.assign": "4.0.4"
+      },
       "dependencies": {
         "doctrine": {
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "esutils": "2.0.2",
+            "isarray": "1.0.0"
+          }
         }
       }
     },
@@ -579,6 +1070,10 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
       "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
+      "requires": {
+        "acorn": "5.0.3",
+        "acorn-jsx": "3.0.1"
+      },
       "dependencies": {
         "acorn": {
           "version": "5.0.3",
@@ -595,12 +1090,19 @@
     "esquery": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
-      "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo="
+      "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+      "requires": {
+        "estraverse": "4.2.0"
+      }
     },
     "esrecurse": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
       "integrity": "sha1-RxO2U2rffyrE8yfVWed1a/9kgiA=",
+      "requires": {
+        "estraverse": "4.1.1",
+        "object-assign": "4.1.1"
+      },
       "dependencies": {
         "estraverse": {
           "version": "4.1.1",
@@ -622,7 +1124,11 @@
     "event-emitter": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
-      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk="
+      "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+      "requires": {
+        "d": "1.0.0",
+        "es5-ext": "0.10.23"
+      }
     },
     "exit-hook": {
       "version": "1.1.1",
@@ -634,6 +1140,12 @@
       "resolved": "https://registry.npmjs.org/falafel/-/falafel-1.2.0.tgz",
       "integrity": "sha1-wY0k71CRF0pJfzGM0ksCaiXN2rQ=",
       "dev": true,
+      "requires": {
+        "acorn": "1.2.2",
+        "foreach": "2.0.5",
+        "isarray": "0.0.1",
+        "object-keys": "1.0.11"
+      },
       "dependencies": {
         "acorn": {
           "version": "1.2.2",
@@ -657,17 +1169,31 @@
     "figures": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
-      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4="
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "requires": {
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
+      }
     },
     "file-entry-cache": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
-      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E="
+      "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+      "requires": {
+        "flat-cache": "1.2.2",
+        "object-assign": "4.1.1"
+      }
     },
     "flat-cache": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
-      "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y="
+      "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
+      "requires": {
+        "circular-json": "0.3.1",
+        "del": "2.2.2",
+        "graceful-fs": "4.1.11",
+        "write": "0.2.1"
+      }
     },
     "foreach": {
       "version": "2.0.5",
@@ -681,9 +1207,9 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "function-bind": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.0.tgz",
-      "integrity": "sha1-FhdnFMgBeY5Ojyz391KUZ7tKV3E=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
     },
     "generate-function": {
@@ -694,12 +1220,31 @@
     "generate-object-property": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA="
+      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+      "requires": {
+        "is-property": "1.0.2"
+      }
+    },
+    "get-amd-module-type": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-amd-module-type/-/get-amd-module-type-2.0.5.tgz",
+      "integrity": "sha1-5nHsWpatX79To6IqKJ6SOMdy3bA=",
+      "requires": {
+        "ast-module-types": "2.3.2",
+        "node-source-walk": "3.3.0"
+      }
     },
     "glob": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-      "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI="
+      "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+      "requires": {
+        "inflight": "1.0.6",
+        "inherits": "2.0.3",
+        "minimatch": "3.0.4",
+        "once": "1.4.0",
+        "path-is-absolute": "1.0.1"
+      }
     },
     "globals": {
       "version": "9.18.0",
@@ -710,11 +1255,42 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+      "requires": {
+        "array-union": "1.0.2",
+        "arrify": "1.0.1",
+        "glob": "7.1.2",
+        "object-assign": "4.1.1",
+        "pify": "2.3.0",
+        "pinkie-promise": "2.0.1"
+      },
       "dependencies": {
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ=="
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        }
+      }
+    },
+    "gonzales-pe": {
+      "version": "3.4.7",
+      "resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-3.4.7.tgz",
+      "integrity": "sha1-F8e+Z61sr/Ynej44esc26YPSgOw=",
+      "requires": {
+        "minimist": "1.1.3"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
+          "integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag="
         }
       }
     },
@@ -733,17 +1309,23 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "function-bind": "1.1.1"
+      }
     },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE="
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "hosted-git-info": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
-      "integrity": "sha1-AHa59GonBQbduq6lZJaJdGBhKmc="
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
     },
     "ignore": {
       "version": "3.3.3",
@@ -758,7 +1340,11 @@
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk="
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "1.4.0",
+        "wrappy": "1.0.2"
+      }
     },
     "inherits": {
       "version": "2.0.3",
@@ -774,7 +1360,22 @@
     "inquirer": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
-      "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34="
+      "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+      "requires": {
+        "ansi-escapes": "1.4.0",
+        "ansi-regex": "2.1.1",
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-width": "2.1.0",
+        "figures": "1.7.0",
+        "lodash": "4.17.4",
+        "readline2": "1.0.1",
+        "run-async": "0.1.0",
+        "rx-lite": "3.1.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "through": "2.3.8"
+      }
     },
     "interpret": {
       "version": "1.0.3",
@@ -785,12 +1386,18 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "loose-envify": "1.3.1"
+      }
     },
     "is-builtin-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74="
+      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "requires": {
+        "builtin-modules": "1.1.1"
+      }
     },
     "is-callable": {
       "version": "1.1.3",
@@ -807,12 +1414,21 @@
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "requires": {
+        "number-is-nan": "1.0.1"
+      }
     },
     "is-my-json-valid": {
       "version": "2.16.0",
       "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
-      "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM="
+      "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
+      "requires": {
+        "generate-function": "2.0.0",
+        "generate-object-property": "1.2.0",
+        "jsonpointer": "4.0.1",
+        "xtend": "4.0.1"
+      }
     },
     "is-path-cwd": {
       "version": "1.0.0",
@@ -822,12 +1438,18 @@
     "is-path-in-cwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
-      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw="
+      "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+      "requires": {
+        "is-path-inside": "1.0.0"
+      }
     },
     "is-path-inside": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
-      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838="
+      "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+      "requires": {
+        "path-is-inside": "1.0.2"
+      }
     },
     "is-property": {
       "version": "1.0.2",
@@ -838,17 +1460,26 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "has": "1.0.1"
+      }
     },
     "is-relative": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/is-relative/-/is-relative-0.2.1.tgz",
-      "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU="
+      "integrity": "sha1-0n9MfVFtF1+2ENuEu+7yPDvJeqU=",
+      "requires": {
+        "is-unc-path": "0.1.2"
+      }
     },
     "is-resolvable": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
-      "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI="
+      "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
+      "requires": {
+        "tryit": "1.0.3"
+      }
     },
     "is-symbol": {
       "version": "1.0.1",
@@ -859,7 +1490,10 @@
     "is-unc-path": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/is-unc-path/-/is-unc-path-0.1.2.tgz",
-      "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk="
+      "integrity": "sha1-arBTpyVzwQJQ/0FqOBTDUXivObk=",
+      "requires": {
+        "unc-path-regex": "0.1.2"
+      }
     },
     "isarray": {
       "version": "1.0.0",
@@ -877,6 +1511,10 @@
       "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
       "integrity": "sha1-jxDXl32NefL2/4YqgbBRPMslaGw=",
       "dev": true,
+      "requires": {
+        "commander": "0.6.1",
+        "mkdirp": "0.3.0"
+      },
       "dependencies": {
         "commander": {
           "version": "0.6.1",
@@ -892,11 +1530,6 @@
         }
       }
     },
-    "jju": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/jju/-/jju-1.3.0.tgz",
-      "integrity": "sha1-2t2e8BkkvHKLA/L3l5vb1i96Kqo="
-    },
     "js-tokens": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
@@ -906,6 +1539,10 @@
       "version": "3.8.4",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
       "integrity": "sha1-UgtFZPhlc7qWZir4Woyvp7S1pvY=",
+      "requires": {
+        "argparse": "1.0.9",
+        "esprima": "3.1.3"
+      },
       "dependencies": {
         "esprima": {
           "version": "3.1.3",
@@ -919,30 +1556,58 @@
       "resolved": "https://registry.npmjs.org/jsfmt/-/jsfmt-0.5.3.tgz",
       "integrity": "sha1-oPOzPyIpbQv1qcTBoZUVHzSOsDY=",
       "dev": true,
+      "requires": {
+        "deep-extend": "0.4.2",
+        "docopt": "0.4.1",
+        "escodegen": "1.7.1",
+        "esformatter": "0.9.6",
+        "esformatter-braces": "1.2.1",
+        "esformatter-var-each": "2.1.0",
+        "esprima": "2.7.3",
+        "falafel": "1.2.0",
+        "glob": "5.0.15",
+        "rc": "1.1.7",
+        "rocambole": "0.7.0",
+        "tmp": "0.0.31",
+        "underscore": "1.8.3"
+      },
       "dependencies": {
         "glob": {
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         },
         "rocambole": {
           "version": "0.7.0",
           "resolved": "https://registry.npmjs.org/rocambole/-/rocambole-0.7.0.tgz",
           "integrity": "sha1-9seVBVF9xCtvuECEK4uVOw+WhYU=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "esprima": "2.7.3"
+          }
         }
       }
     },
-    "json-parse-helpfulerror": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/json-parse-helpfulerror/-/json-parse-helpfulerror-1.0.3.tgz",
-      "integrity": "sha1-E/FM4C7tTpgSl7ZOueO5MuLdE9w="
+    "json-parse-better-errors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
+      "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw=="
     },
     "json-stable-stringify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8="
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "requires": {
+        "jsonify": "0.0.0"
+      }
     },
     "jsonify": {
       "version": "0.0.0",
@@ -963,7 +1628,11 @@
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4="
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "requires": {
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2"
+      }
     },
     "lodash": {
       "version": "4.17.4",
@@ -973,12 +1642,22 @@
     "lodash._baseassign": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash._baseassign/-/lodash._baseassign-3.2.0.tgz",
-      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4="
+      "integrity": "sha1-jDigmVAPIVrQnlnxci/QxSv+Ck4=",
+      "requires": {
+        "lodash._basecopy": "3.0.1",
+        "lodash.keys": "3.1.2"
+      }
     },
     "lodash._basecallback": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/lodash._basecallback/-/lodash._basecallback-3.3.1.tgz",
-      "integrity": "sha1-t7K7Q9whYEJKIczybFfkQ3cqjic="
+      "integrity": "sha1-t7K7Q9whYEJKIczybFfkQ3cqjic=",
+      "requires": {
+        "lodash._baseisequal": "3.0.7",
+        "lodash._bindcallback": "3.0.1",
+        "lodash.isarray": "3.0.4",
+        "lodash.pairs": "3.0.1"
+      }
     },
     "lodash._basecopy": {
       "version": "3.0.1",
@@ -993,12 +1672,22 @@
     "lodash._baseisequal": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/lodash._baseisequal/-/lodash._baseisequal-3.0.7.tgz",
-      "integrity": "sha1-2AJfdjOdKTQnZ9zIh85cuVpbUfE="
+      "integrity": "sha1-2AJfdjOdKTQnZ9zIh85cuVpbUfE=",
+      "requires": {
+        "lodash.isarray": "3.0.4",
+        "lodash.istypedarray": "3.0.6",
+        "lodash.keys": "3.1.2"
+      }
     },
     "lodash._baseuniq": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash._baseuniq/-/lodash._baseuniq-3.0.3.tgz",
-      "integrity": "sha1-ISP6DbLWnCjVvrHB821hUip0AjQ="
+      "integrity": "sha1-ISP6DbLWnCjVvrHB821hUip0AjQ=",
+      "requires": {
+        "lodash._baseindexof": "3.1.0",
+        "lodash._cacheindexof": "3.0.2",
+        "lodash._createcache": "3.1.2"
+      }
     },
     "lodash._bindcallback": {
       "version": "3.0.1",
@@ -1013,12 +1702,20 @@
     "lodash._createassigner": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lodash._createassigner/-/lodash._createassigner-3.1.1.tgz",
-      "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE="
+      "integrity": "sha1-g4pbri/aymOsIt7o4Z+k5taXCxE=",
+      "requires": {
+        "lodash._bindcallback": "3.0.1",
+        "lodash._isiterateecall": "3.0.9",
+        "lodash.restparam": "3.6.1"
+      }
     },
     "lodash._createcache": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash._createcache/-/lodash._createcache-3.1.2.tgz",
-      "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM="
+      "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
+      "requires": {
+        "lodash._getnative": "3.9.1"
+      }
     },
     "lodash._getnative": {
       "version": "3.9.1",
@@ -1033,12 +1730,21 @@
     "lodash.assign": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-3.2.0.tgz",
-      "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo="
+      "integrity": "sha1-POnwI0tLIiPilrj6CsH+6OvKZPo=",
+      "requires": {
+        "lodash._baseassign": "3.2.0",
+        "lodash._createassigner": "3.1.1",
+        "lodash.keys": "3.1.2"
+      }
     },
     "lodash.defaults": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-3.1.2.tgz",
-      "integrity": "sha1-xzCLGNv4vJNy1wGnNJPGEZK9Liw="
+      "integrity": "sha1-xzCLGNv4vJNy1wGnNJPGEZK9Liw=",
+      "requires": {
+        "lodash.assign": "3.2.0",
+        "lodash.restparam": "3.6.1"
+      }
     },
     "lodash.isarguments": {
       "version": "3.1.0",
@@ -1058,34 +1764,59 @@
     "lodash.keys": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-3.1.2.tgz",
-      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo="
+      "integrity": "sha1-TbwEcrFWvlCgsoaFXRvQsMZWCYo=",
+      "requires": {
+        "lodash._getnative": "3.9.1",
+        "lodash.isarguments": "3.1.0",
+        "lodash.isarray": "3.0.4"
+      }
     },
     "lodash.pairs": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/lodash.pairs/-/lodash.pairs-3.0.1.tgz",
-      "integrity": "sha1-u+CNV4bu6qCaFckevw3LfSvjJqk="
-    },
-    "lodash.pickby": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/lodash.pickby/-/lodash.pickby-4.6.0.tgz",
-      "integrity": "sha1-feoh2MGNdwOifHBMFdO4SmfjOv8=",
-      "dev": true
+      "integrity": "sha1-u+CNV4bu6qCaFckevw3LfSvjJqk=",
+      "requires": {
+        "lodash.keys": "3.1.2"
+      }
     },
     "lodash.restparam": {
       "version": "3.6.1",
       "resolved": "https://registry.npmjs.org/lodash.restparam/-/lodash.restparam-3.6.1.tgz",
       "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
     },
+    "lodash.tostring": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/lodash.tostring/-/lodash.tostring-4.1.4.tgz",
+      "integrity": "sha1-Vgwn0fjq3eA8LM4Zj+9cAx2CmPs="
+    },
+    "lodash.unescape": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/lodash.unescape/-/lodash.unescape-4.0.0.tgz",
+      "integrity": "sha1-Nt6/xJK4FHhHHvl0zTeD4gLrbO8=",
+      "requires": {
+        "lodash.tostring": "4.1.4"
+      }
+    },
     "lodash.uniq": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-3.2.2.tgz",
-      "integrity": "sha1-FGw28l510ZUBukAuiLoUk39jzYs="
+      "integrity": "sha1-FGw28l510ZUBukAuiLoUk39jzYs=",
+      "requires": {
+        "lodash._basecallback": "3.3.1",
+        "lodash._baseuniq": "3.0.3",
+        "lodash._getnative": "3.9.1",
+        "lodash._isiterateecall": "3.0.9",
+        "lodash.isarray": "3.0.4"
+      }
     },
     "loose-envify": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "js-tokens": "3.0.1"
+      }
     },
     "lru-cache": {
       "version": "2.7.3",
@@ -1096,7 +1827,10 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA=="
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "requires": {
+        "brace-expansion": "1.1.8"
+      }
     },
     "minimist": {
       "version": "1.2.0",
@@ -1107,6 +1841,9 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      },
       "dependencies": {
         "minimist": {
           "version": "0.0.8",
@@ -1120,12 +1857,27 @@
       "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
       "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
       "dev": true,
+      "requires": {
+        "commander": "2.3.0",
+        "debug": "2.2.0",
+        "diff": "1.4.0",
+        "escape-string-regexp": "1.0.2",
+        "glob": "3.2.11",
+        "growl": "1.9.2",
+        "jade": "0.26.3",
+        "mkdirp": "0.5.1",
+        "supports-color": "1.2.0",
+        "to-iso-string": "0.0.2"
+      },
       "dependencies": {
         "debug": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
           "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "ms": "0.7.1"
+          }
         },
         "escape-string-regexp": {
           "version": "1.0.2",
@@ -1137,13 +1889,21 @@
           "version": "3.2.11",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
           "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.3",
+            "minimatch": "0.3.0"
+          }
         },
         "minimatch": {
           "version": "0.3.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
           "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "lru-cache": "2.7.3",
+            "sigmund": "1.0.1"
+          }
         },
         "ms": {
           "version": "0.7.1",
@@ -1159,17 +1919,63 @@
         }
       }
     },
+    "module-definition": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/module-definition/-/module-definition-2.2.4.tgz",
+      "integrity": "sha1-wKN3HeWM9rzxKu0kdnBsWWrUsss=",
+      "requires": {
+        "ast-module-types": "2.3.2",
+        "node-source-walk": "3.3.0"
+      }
+    },
     "mongodb-js-fmt": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/mongodb-js-fmt/-/mongodb-js-fmt-0.0.3.tgz",
       "integrity": "sha1-8f9ZvXLaorG7FGTmI2PsCKaFU70=",
       "dev": true,
+      "requires": {
+        "async": "1.5.2",
+        "chalk": "1.1.3",
+        "debug": "2.6.9",
+        "esformatter-braces": "1.2.1",
+        "esformatter-dot-notation": "1.3.1",
+        "esformatter-eol-last": "1.0.0",
+        "esformatter-parseint": "1.0.3",
+        "esformatter-quote-props": "1.0.2",
+        "esformatter-quotes": "1.1.0",
+        "esformatter-remove-trailing-commas": "1.0.1",
+        "esformatter-semicolons": "1.1.2",
+        "esformatter-spaced-lined-comment": "2.0.1",
+        "esformatter-var-each": "2.1.0",
+        "figures": "1.7.0",
+        "glob": "5.0.15",
+        "jsfmt": "0.5.3",
+        "lodash.defaults": "3.1.2",
+        "lodash.uniq": "3.2.2",
+        "minimist": "1.2.0"
+      },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "glob": {
           "version": "5.0.15",
           "resolved": "https://registry.npmjs.org/glob/-/glob-5.0.15.tgz",
           "integrity": "sha1-G8k2ueAvSmA/zCIuz3Yz0wuLk7E=",
-          "dev": true
+          "dev": true,
+          "requires": {
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         }
       }
     },
@@ -1194,28 +2000,58 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc="
     },
+    "node-source-walk": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/node-source-walk/-/node-source-walk-3.3.0.tgz",
+      "integrity": "sha1-rRjjW/2z0Lb34OSv8eePhGo7iHM=",
+      "requires": {
+        "babylon": "6.17.3"
+      }
+    },
     "normalize-package-data": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
-      "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs="
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "requires": {
+        "hosted-git-info": "2.5.0",
+        "is-builtin-module": "1.0.0",
+        "semver": "5.4.1",
+        "validate-npm-package-license": "3.0.1"
+      }
     },
     "npm-path": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-1.1.0.tgz",
       "integrity": "sha1-BHSuAEGcMn1UcBt88s0F3Ii+EUA=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "which": "1.2.14"
+      }
     },
     "npm-run": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/npm-run/-/npm-run-2.0.0.tgz",
       "integrity": "sha1-KN/ArV4uRv4ISOK9WN3wAue3PBU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "minimist": "1.2.0",
+        "npm-path": "1.1.0",
+        "npm-which": "2.0.0",
+        "serializerr": "1.0.3",
+        "spawn-sync": "1.0.15",
+        "sync-exec": "0.5.0"
+      }
     },
     "npm-which": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/npm-which/-/npm-which-2.0.0.tgz",
       "integrity": "sha1-DEaYIWC3gwk2YdHQG9RJbS/qu6w=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "commander": "2.3.0",
+        "npm-path": "1.1.0",
+        "which": "1.2.14"
+      }
     },
     "number-is-nan": {
       "version": "1.0.1",
@@ -1237,12 +2073,20 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.0.4.tgz",
       "integrity": "sha1-scnMBE7xuf5jYG/BQau7MuFHMMw=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "define-properties": "1.1.2",
+        "function-bind": "1.1.1",
+        "object-keys": "1.0.11"
+      }
     },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E="
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1.0.2"
+      }
     },
     "onetime": {
       "version": "1.1.0",
@@ -1252,7 +2096,15 @@
     "optionator": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q="
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "requires": {
+        "deep-is": "0.1.3",
+        "fast-levenshtein": "2.0.6",
+        "levn": "0.3.0",
+        "prelude-ls": "1.1.2",
+        "type-check": "0.3.2",
+        "wordwrap": "1.0.0"
+      }
     },
     "os-homedir": {
       "version": "1.0.2",
@@ -1299,7 +2151,10 @@
     "pinkie-promise": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o="
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "requires": {
+        "pinkie": "2.0.4"
+      }
     },
     "pluralize": {
       "version": "1.2.1",
@@ -1310,7 +2165,38 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/pre-commit/-/pre-commit-1.2.2.tgz",
       "integrity": "sha1-287g7p3nI15X95xW186UZBpp7sY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "cross-spawn": "5.1.0",
+        "spawn-sync": "1.0.15",
+        "which": "1.2.14"
+      }
+    },
+    "precinct": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/precinct/-/precinct-3.8.0.tgz",
+      "integrity": "sha1-JZqUkKhUd6HyaYn73y+ybETyR1o=",
+      "requires": {
+        "commander": "2.11.0",
+        "debug": "3.1.0",
+        "detective-amd": "2.4.0",
+        "detective-cjs": "2.0.0",
+        "detective-es6": "1.2.0",
+        "detective-less": "1.0.0",
+        "detective-sass": "2.0.1",
+        "detective-scss": "1.0.1",
+        "detective-stylus": "1.0.0",
+        "detective-typescript": "1.0.1",
+        "module-definition": "2.2.4",
+        "node-source-walk": "3.3.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.11.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
+          "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ=="
+        }
+      }
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -1343,40 +2229,77 @@
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.1.7.tgz",
       "integrity": "sha1-xepWS7B6/5/TpbMukGwdOmWUD+o=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "deep-extend": "0.4.2",
+        "ini": "1.3.4",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
+      }
     },
     "read-package-json": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.5.tgz",
-      "integrity": "sha1-+Tpk5kFSnfaKCMZN5GOJ6KP4iEU=",
+      "version": "2.0.12",
+      "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.0.12.tgz",
+      "integrity": "sha512-m7/I0+tP6D34EVvSlzCtuVA4D/dHL6OpLcn2e4XVP5X57pCKGUy1JjRSBVKHWpB+vUU91sL85h84qX0MdXzBSw==",
+      "requires": {
+        "glob": "7.1.2",
+        "graceful-fs": "4.1.11",
+        "json-parse-better-errors": "1.0.1",
+        "normalize-package-data": "2.4.0",
+        "slash": "1.0.0"
+      },
       "dependencies": {
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ=="
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         }
       }
     },
     "readable-stream": {
       "version": "2.2.11",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
-      "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q=="
+      "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
+      "requires": {
+        "core-util-is": "1.0.2",
+        "inherits": "2.0.3",
+        "isarray": "1.0.0",
+        "process-nextick-args": "1.0.7",
+        "safe-buffer": "5.0.1",
+        "string_decoder": "1.0.2",
+        "util-deprecate": "1.0.2"
+      }
     },
     "readline2": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
-      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU="
+      "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "mute-stream": "0.0.5"
+      }
     },
     "rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q="
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "requires": {
+        "resolve": "1.3.3"
+      }
     },
     "regenerator-runtime": {
       "version": "0.10.5",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg=",
-      "dev": true
+      "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
     },
     "repeat-string": {
       "version": "1.6.1",
@@ -1387,12 +2310,19 @@
     "require-uncached": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
-      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM="
+      "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+      "requires": {
+        "caller-path": "0.1.0",
+        "resolve-from": "1.0.1"
+      }
     },
     "resolve": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
-      "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU="
+      "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
+      "requires": {
+        "path-parse": "1.0.5"
+      }
     },
     "resolve-from": {
       "version": "1.0.1",
@@ -1402,31 +2332,63 @@
     "restore-cursor": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
-      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE="
+      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "requires": {
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
+      }
     },
     "rimraf": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
       "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+      "requires": {
+        "glob": "7.1.2"
+      },
       "dependencies": {
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ=="
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         }
       }
     },
     "rocambole": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/rocambole/-/rocambole-0.6.0.tgz",
-      "integrity": "sha1-U08jWih8wX+bBXuVvRHQ8Nw1RSw="
+      "integrity": "sha1-U08jWih8wX+bBXuVvRHQ8Nw1RSw=",
+      "requires": {
+        "esprima": "2.7.3"
+      }
     },
     "rocambole-indent": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/rocambole-indent/-/rocambole-indent-2.0.4.tgz",
       "integrity": "sha1-oYokl3ygQAuGHapGMehh3LUtCFw=",
       "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "mout": "0.11.1",
+        "rocambole-token": "1.2.1"
+      },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "mout": {
           "version": "0.11.1",
           "resolved": "https://registry.npmjs.org/mout/-/mout-0.11.1.tgz",
@@ -1440,7 +2402,21 @@
       "resolved": "https://registry.npmjs.org/rocambole-linebreak/-/rocambole-linebreak-1.0.2.tgz",
       "integrity": "sha1-A2IVFbQ7RyHJflocG8paA2Y2jy8=",
       "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "rocambole-token": "1.2.1",
+        "semver": "4.3.6"
+      },
       "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "semver": {
           "version": "4.3.6",
           "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz",
@@ -1464,12 +2440,31 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/rocambole-whitespace/-/rocambole-whitespace-1.0.0.tgz",
       "integrity": "sha1-YzMJSSVrKZQfWbGQRZ+ZnGsdO/k=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "repeat-string": "1.6.1",
+        "rocambole-token": "1.2.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "2.6.9",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        }
+      }
     },
     "run-async": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
-      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k="
+      "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+      "requires": {
+        "once": "1.4.0"
+      }
     },
     "rx-lite": {
       "version": "3.1.2",
@@ -1482,21 +2477,27 @@
       "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
     },
     "semver": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
     },
     "serializerr": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/serializerr/-/serializerr-1.0.3.tgz",
       "integrity": "sha1-EtTFqhw/+49tHcXzlaqUVVacP5E=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "protochain": "1.0.5"
+      }
     },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "shebang-regex": "1.0.0"
+      }
     },
     "shebang-regex": {
       "version": "1.0.0",
@@ -1508,11 +2509,24 @@
       "version": "0.7.8",
       "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
       "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+      "requires": {
+        "glob": "7.1.2",
+        "interpret": "1.0.3",
+        "rechoir": "0.6.2"
+      },
       "dependencies": {
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
-          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ=="
+          "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
         }
       }
     },
@@ -1521,6 +2535,11 @@
       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
       "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
       "dev": true
+    },
+    "slash": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
     },
     "slice-ansi": {
       "version": "0.0.4",
@@ -1532,18 +2551,28 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
       "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
       "dev": true,
-      "optional": true
+      "optional": true,
+      "requires": {
+        "amdefine": "1.0.1"
+      }
     },
     "spawn-sync": {
       "version": "1.0.15",
       "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
       "integrity": "sha1-sAeZVX63+wyDdsKdROih6mfldHY=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "concat-stream": "1.6.0",
+        "os-shim": "0.1.3"
+      }
     },
     "spdx-correct": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A="
+      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+      "requires": {
+        "spdx-license-ids": "1.2.2"
+      }
     },
     "spdx-expression-parse": {
       "version": "1.0.4",
@@ -1566,15 +2595,15 @@
       "integrity": "sha1-0wQZgarsPf28d6GzjWNy449ftx4=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
-      "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk="
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M="
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "requires": {
+        "code-point-at": "1.1.0",
+        "is-fullwidth-code-point": "1.0.0",
+        "strip-ansi": "3.0.1"
+      }
     },
     "string.prototype.endswith": {
       "version": "0.2.0",
@@ -1582,10 +2611,21 @@
       "integrity": "sha1-oZwg3uUamHd+mkfhDwm+OTubunU=",
       "dev": true
     },
+    "string_decoder": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
+      "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
+      "requires": {
+        "safe-buffer": "5.0.1"
+      }
+    },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "requires": {
+        "ansi-regex": "2.1.1"
+      }
     },
     "strip-bom": {
       "version": "3.0.0",
@@ -1612,6 +2652,14 @@
       "version": "3.8.3",
       "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
       "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+      "requires": {
+        "ajv": "4.11.8",
+        "ajv-keywords": "1.5.1",
+        "chalk": "1.1.3",
+        "lodash": "4.17.4",
+        "slice-ansi": "0.0.4",
+        "string-width": "2.0.0"
+      },
       "dependencies": {
         "is-fullwidth-code-point": {
           "version": "2.0.0",
@@ -1621,7 +2669,11 @@
         "string-width": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
-          "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4="
+          "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
+          "requires": {
+            "is-fullwidth-code-point": "2.0.0",
+            "strip-ansi": "3.0.1"
+          }
         }
       }
     },
@@ -1639,7 +2691,10 @@
       "version": "0.0.31",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz",
       "integrity": "sha1-jzirlDjhcxXl29izZX6L+yd65Kc=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "1.0.2"
+      }
     },
     "to-fast-properties": {
       "version": "1.0.3",
@@ -1661,12 +2716,29 @@
     "type-check": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I="
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "requires": {
+        "prelude-ls": "1.1.2"
+      }
     },
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+    },
+    "typescript": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.0.10.tgz",
+      "integrity": "sha1-zN1O2G/VVQpAcQGggUAS4bP6w90="
+    },
+    "typescript-eslint-parser": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/typescript-eslint-parser/-/typescript-eslint-parser-1.0.2.tgz",
+      "integrity": "sha1-/Sq6zy7j2Tgqs+RJyHYra+rk0Nc=",
+      "requires": {
+        "lodash.unescape": "4.0.0",
+        "object-assign": "4.1.1"
+      }
     },
     "unc-path-regex": {
       "version": "0.1.2",
@@ -1687,7 +2759,10 @@
     "user-home": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8="
+      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+      "requires": {
+        "os-homedir": "1.0.2"
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -1697,13 +2772,20 @@
     "validate-npm-package-license": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w="
+      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+      "requires": {
+        "spdx-correct": "1.0.2",
+        "spdx-expression-parse": "1.0.4"
+      }
     },
     "which": {
       "version": "1.2.14",
       "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
       "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "isexe": "2.0.0"
+      }
     },
     "wordwrap": {
       "version": "1.0.0",
@@ -1718,7 +2800,10 @@
     "write": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
-      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c="
+      "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+      "requires": {
+        "mkdirp": "0.5.1"
+      }
     },
     "xtend": {
       "version": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "license": "Apache-2.0",
   "devDependencies": {
     "eslint-config-mongodb-js": "^2.3.0",
-    "mocha": "^2.3.4",
+    "mocha": "^4.0.1",
     "mongodb-js-fmt": "0.0.3",
     "pre-commit": "^1.1.2"
   }

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "description": "Shared static analysis and integrity tooling.",
   "version": "0.3.0",
   "author": "Lucas Hrabovsky <lucas@mongodb.com> (http://imlucas.com)",
-  "homepage": "http://github.com/10gen/scout",
+  "homepage": "https://github.com/mongodb-js/precommit",
   "repository": {
     "type": "git",
-    "url": "git://github.com/10gen/scout.git"
+    "url": "git://github.com/mongodb-js/precommit.git"
   },
   "scripts": {
     "test": "mocha",
@@ -24,8 +24,8 @@
   "dependencies": {
     "async": "^1.5.0",
     "chalk": "^1.1.1",
-    "debug": "^2.2.0",
-    "dependency-check": "2.8.0",
+    "debug": "^3.1.0",
+    "dependency-check": "^2.9.1",
     "esformatter-braces": "^1.2.1",
     "esformatter-dot-notation": "^1.3.1",
     "esformatter-quote-props": "^1.0.2",
@@ -39,7 +39,8 @@
     "lodash.assign": "^3.2.0",
     "lodash.defaults": "^3.1.2",
     "lodash.uniq": "^3.2.2",
-    "minimist": "^1.2.0"
+    "minimist": "^1.2.0",
+    "precinct": "^3.8.0"
   },
   "dependency-check": {
     "ignore": [
@@ -54,7 +55,7 @@
   },
   "license": "Apache-2.0",
   "devDependencies": {
-    "eslint-config-mongodb-js": "^2.1.0",
+    "eslint-config-mongodb-js": "^2.3.0",
     "mocha": "^2.3.4",
     "mongodb-js-fmt": "0.0.3",
     "pre-commit": "^1.1.2"

--- a/usage.txt
+++ b/usage.txt
@@ -13,3 +13,4 @@ Options:
   --debug        Enable debug messages.
   -h --help      Show this screen.
   --version      Show version.
+  --detective    Use a different parser for the `dependency-check`. [Default: `precinct`].


### PR DESCRIPTION
Added support for parsing the `--detective` flag to override the parser that the `dependency-check` package uses.

- Updated `usage.txt` to show the `--detective` option when running the `--help` flag.
- Added support for the `--detective` argument.
- Installed and updated dependencies
- Set the default detective to "precinct" - which under the hooded uses the `detective-es6` package allowing us to support dependency checks for ES6 import/export statements as well as require statements.